### PR TITLE
fix links in readme.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Tonic LND client
 
-[![Crate](https://img.shields.io/crates/v/tonic_lnd.svg?logo=rust)]([https://crates.io/crates/lightning](https://crates.io/crates/tonic_lnd))
-[![Documentation](https://img.shields.io/static/v1?logo=read-the-docs&label=docs.rs&message=tonic_lnd&color=informational)](https://docs.rs/tonic_lnd/)
+[![Crate](https://img.shields.io/crates/v/fedimint-tonic-lnd.svg?logo=rust)](https://crates.io/crates/fedimint-tonic-lnd)
+[![Documentation](https://img.shields.io/static/v1?logo=read-the-docs&label=docs.rs&message=fedimint-tonic-lnd&color=informational)](https://docs.rs/fedimint-tonic-lnd/)
 
 Rust implementation of LND RPC client using async gRPC library `tonic`.
 


### PR DESCRIPTION
Fixes the links in the readme to point to the new crate on crates.io