### PR TITLE
Prepare v0.2 release

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -200,7 +200,7 @@ checksum = "25cbce373ec4653f1a01a31e8a5e5ec0c622dc27ff9c4e6606eefef5cbbed4a5"
 
 [[package]]
 name = "fedimint-tonic-lnd"
-version = "0.1.3"
+version = "0.2.0"
 dependencies = [
  "hex",
  "http-body",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fedimint-tonic-lnd"
-version = "0.1.3"
+version = "0.2.0"
 edition = "2021"
 rust-version = "1.65.0"
 description = "An async library implementing LND RPC via tonic and prost. Forked from https://github.com/Kixunil/tonic_lnd"


### PR DESCRIPTION
I didn't want to check if we broke API compatibility in any of the many commits since the last release. SemVer correctness > saving version numbers.