### PR TITLE
chore: add proto RPC for Tracking Payments

### DIFF
--- a/examples/track_payments.rs
+++ b/examples/track_payments.rs
@@ -1,0 +1,62 @@
+// This example connects to LND and uses router rpc to track a payment.
+//
+// The program accepts four arguments: address, cert file, macaroon file, payment hash
+// The address must start with `https://`!
+//
+// Example run: `cargo run --features=routerrpc --example track_payments <address> <tls.cert> <file.macaroon> <payment_hash>`
+
+#[tokio::main]
+#[cfg(feature = "routerrpc")]
+async fn main() {
+    let mut args = std::env::args_os();
+    args.next().expect("not even zeroth arg given");
+    let address: String = args
+        .next()
+        .expect("missing arguments: address, macaroon file, payment hash")
+        .into_string()
+        .expect("address is not UTF-8");
+    let cert_file: String = args
+        .next()
+        .expect("missing arguments: cert file, macaroon file, payment hash")
+        .into_string()
+        .expect("cert_file is not UTF-8");
+    let macaroon_file: String = args
+        .next()
+        .expect("missing argument: macaroon file, payment hash")
+        .into_string()
+        .expect("macaroon_file is not UTF-8");
+
+    // Connecting to LND requires only address, cert file, and macaroon file
+    let mut client = fedimint_tonic_lnd::connect(address, cert_file, macaroon_file)
+        .await
+        .expect("failed to connect");
+
+    match client
+        .router()
+        .track_payments(fedimint_tonic_lnd::routerrpc::TrackPaymentsRequest {
+            no_inflight_updates: true,
+        })
+        .await
+    {
+        Ok(response) => {
+            let mut response = response.into_inner();
+            loop {
+                println!("Waiting for payment...");
+                match response.message().await {
+                    Ok(Some(payment)) => {
+                        println!("Got payment: {:#?}", payment);
+                    }
+                    Ok(None) => {
+                        println!("Payments stream ended");
+                    }
+                    Err(e) => {
+                        eprintln!("Error reading payment stream: {e:?}");
+                    }
+                }
+            }
+        }
+        Err(e) => {
+            eprintln!("Error subscribing to payments stream: {e:?}");
+        }
+    }
+}

--- a/vendor/routerrpc/router.proto
+++ b/vendor/routerrpc/router.proto
@@ -23,6 +23,16 @@ service Router {
     rpc TrackPaymentV2 (TrackPaymentRequest) returns (stream lnrpc.Payment);
 
     /*
+    TrackPayments returns an update stream for every payment that is not in a
+    terminal state. Note that if payments are in-flight while starting a new
+    subscription, the start of the payment stream could produce out-of-order
+    and/or duplicate events. In order to get updates for every in-flight
+    payment attempt make sure to subscribe to this method before initiating any
+    payments.
+    */
+    rpc TrackPayments (TrackPaymentsRequest) returns (stream lnrpc.Payment);
+
+    /*
     EstimateRouteFee allows callers to obtain a lower bound w.r.t how much it
     may cost to send an HTLC to the target end destination.
     */
@@ -302,6 +312,15 @@ message TrackPaymentRequest {
     */
     bool no_inflight_updates = 2;
 }
+
+message TrackPaymentsRequest {
+    /*
+    If set, only the final payment updates are streamed back. Intermediate
+    updates that show which htlcs are still in flight are suppressed.
+    */
+    bool no_inflight_updates = 1;
+}
+
 
 message RouteFeeRequest {
     /*


### PR DESCRIPTION
This PR adds the RPC functionality for tracking payments, ref: https://lightning.engineering/api-docs/api/lnd/router/track-payments/index.html

PS:
I was not able to find which LND version is supported by each commit or tag. 
The newer proto versions have deprecated or removed certain fields, which could introduce compatibility issues. To avoid potential breaking changes, I have added only the service that is needed for the tracking payments functionality.
Let me know if this is not the correct approach to add/upgrade LND RPCs