### PR TITLE
chore: bump fedimint-tonic-lnd version

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -261,7 +261,7 @@ checksum = "37909eebbb50d72f9059c3b6d82c0463f2ff062c9e95845c43a6c9c0355411be"
 
 [[package]]
 name = "fedimint-tonic-lnd"
-version = "0.3.0"
+version = "0.4.0"
 dependencies = [
  "hex",
  "hyper",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fedimint-tonic-lnd"
-version = "0.3.0"
+version = "0.4.0"
 edition = "2021"
 rust-version = "1.65.0"
 description = "An async library implementing LND RPC via tonic and prost. Forked from https://github.com/Kixunil/tonic_lnd"


### PR DESCRIPTION
Bumping to `v0.4.0` so we can publish to crates